### PR TITLE
Adds OutcomeOf::asResult with an onAbsent conversion

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -37,6 +37,7 @@ public final class app/cash/quiver/OutcomeKt {
 	public static final fun asOption (Lapp/cash/quiver/Outcome;)Larrow/core/Option;
 	public static final fun asOutcome (Larrow/core/Either;)Lapp/cash/quiver/Outcome;
 	public static final fun asResult (Lapp/cash/quiver/Outcome;)Ljava/lang/Object;
+	public static final fun asResult (Lapp/cash/quiver/Outcome;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static final fun failure (Ljava/lang/Object;)Lapp/cash/quiver/Outcome;
 	public static final fun filter (Lapp/cash/quiver/Outcome;Lkotlin/jvm/functions/Function1;)Lapp/cash/quiver/Outcome;
 	public static final fun flatMap (Lapp/cash/quiver/Outcome;Lkotlin/jvm/functions/Function1;)Lapp/cash/quiver/Outcome;


### PR DESCRIPTION
This adds a new method similar to `asEither`.