### PR TITLE
Deprecates Outcome DSL syntax preferring the Raise DSL

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -119,6 +119,10 @@ public final class app/cash/quiver/continuations/OutcomeEagerEffectScope : arrow
 	public final synthetic fun unbox-impl ()Larrow/core/continuations/EagerEffectScope;
 }
 
+public final class app/cash/quiver/continuations/OutcomeEagerEffectScopeKt {
+	public static final field outcomeDSLDeprecation Ljava/lang/String;
+}
+
 public final class app/cash/quiver/continuations/OutcomeEffectScope : arrow/core/continuations/EffectScope {
 	public fun attempt (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun attempt-impl (Larrow/core/continuations/EffectScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/lib/src/main/kotlin/app/cash/quiver/continuations/OutcomeEagerEffectScope.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/continuations/OutcomeEagerEffectScope.kt
@@ -46,13 +46,20 @@ value class OutcomeEffectScope<E>(private val cont: EffectScope<Either<Failure<E
 }
 
 @Suppress("ClassName")
+@Deprecated(outcomeDSLDeprecation, ReplaceWith("outcome", "app.cash.quiver.raise.outcome"))
 object outcome {
+  @Deprecated(outcomeDSLDeprecation, ReplaceWith("outcome(f)", "app.cash.quiver.raise.outcome"))
   inline fun <E, A> eager(crossinline f: suspend OutcomeEagerEffectScope<E>.() -> A): Outcome<E, A> =
     eagerEffect {
       @Suppress("ILLEGAL_RESTRICTED_SUSPENDING_FUNCTION_CALL")
       f(OutcomeEagerEffectScope(this))
     }.fold({ it.merge() }, ::Present)
 
+  @Deprecated(outcomeDSLDeprecation, ReplaceWith("outcome(f)", "app.cash.quiver.raise.outcome"))
   suspend inline operator fun <E, A> invoke(crossinline f: suspend OutcomeEffectScope<E>.() -> A): Outcome<E, A> =
     effect { f(OutcomeEffectScope(this)) }.fold({ it.merge() }, ::Present)
 }
+
+@PublishedApi internal const val outcomeDSLDeprecation =
+  "The outcome DSL has been moved to app.cash.quiver.raise.outcome.\n" +
+    "Replace import app.cash.quiver.continuations.outcome with app.cash.quiver.raise.outcome"


### PR DESCRIPTION
This makes this type inline with the other Arrow types as everything should use the Raise DSL