### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## Unreleased
+
+## [1.0.0]
 * Upgrades Arrow to 2.x (Hugo Müller-Downing)
 * Removes `OutcomeEffectScope` and `OutcomeEagerEffectScope` in favour of `OutcomeBuilder` (Hugo Müller-Downing)
 * Removes methods interacting with `Validated`, as `Validated` is now deprecated (Hugo Müller-Downing)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.quiver
-VERSION_NAME=0.5.14-SNAPSHOT
+VERSION_NAME=1.0.0
 POM_URL=https://github.com/cashapp/quiver/
 POM_SCM_URL=https://github.com/cashapp/quiver/
 POM_SCM_CONNECTION=scm:git:git://github.com/cashapp/quiver.git


### PR DESCRIPTION
### Why 1.x?
By removing `Validated` and associated methods, we are introducing a breaking change, and should use an appropriate [semantic version](https://semver.org/) indicating this.

### Changes in this release
* Upgrades Arrow to 2.x (Hugo Müller-Downing)
* Removes `OutcomeEffectScope` and `OutcomeEagerEffectScope` in favour of `OutcomeBuilder` (Hugo Müller-Downing)
* Removes methods interacting with `Validated`, as `Validated` is now deprecated (Hugo Müller-Downing)
* Replaces `ValidatedNel` with a typealias of `Either<NonEmptyList<E>, A>` (Hugo Müller-Downing)