### PR TITLE
Moves demand to the app.cash.quiver.extension package

### DIFF
--- a/lib/src/main/kotlin/app/cash/quiver/extensions/Demand.kt
+++ b/lib/src/main/kotlin/app/cash/quiver/extensions/Demand.kt
@@ -1,4 +1,5 @@
-import app.cash.quiver.extensions.toResult
+package app.cash.quiver.extensions
+
 import arrow.core.Option
 
 /**

--- a/lib/src/test/kotlin/app/cash/quiver/extensions/DemandTest.kt
+++ b/lib/src/test/kotlin/app/cash/quiver/extensions/DemandTest.kt
@@ -1,9 +1,7 @@
 package app.cash.quiver.extensions;
 
-import ValueIsNull
 import arrow.core.None
 import arrow.core.Some
-import demand
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.result.shouldBeFailure
 import io.kotest.matchers.result.shouldBeSuccess


### PR DESCRIPTION
I forgot the package when defining this originally in https://github.com/block/quiver/pull/126.

These extensions should be appropriately namespaced, so the import isn't global (`import demand`).